### PR TITLE
Hide implementation details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2015 Thomas Ballinger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lazyload/__init__.py
+++ b/lazyload/__init__.py
@@ -1,21 +1,30 @@
 import sys
+from types import ModuleType
 
-class LazyModule(object):
-    """Lazily import a module with minimal side effects"""
-    def __init__(self, module_name):
-        self.module_name = module_name
-        self.module = None
 
-    def __getattr__(self, attr):
-        if not self.module:
-            del sys.modules[self.module_name]
-            self.module = __import__(self.module_name)
-
-            # future imports will get the real module
-            sys.modules[self.module_name] = __import__(self.module_name)
-
-        return getattr(self.module, attr)
+class _LazyModuleMarker(object):
+    pass
 
 
 def make_lazy(module_name):
-    sys.modules[module_name] = LazyModule(module_name)
+    sys_modules = sys.modules  # cache in the locals
+    module = None
+
+    class LazyModule(_LazyModuleMarker):
+        """Lazily import a module with minimal side effects"""
+        def __mro__(self):
+            """Override the __mro__ to fool `isinstance`"""
+            return (LazyModule, ModuleType)
+
+        def __getattribute__(self, attr):
+            """Override __getattribute__ to hide the implementation details"""
+            nonlocal module
+            if module is None:
+                del sys_modules[module_name]
+                module = __import__(module_name)
+
+                sys_modules[module_name] = __import__(module_name)
+
+            return getattr(module, attr)
+
+    sys_modules[module_name] = LazyModule()

--- a/lazyload/__init__.py
+++ b/lazyload/__init__.py
@@ -3,28 +3,48 @@ from types import ModuleType
 
 
 class _LazyModuleMarker(object):
+    """
+    A marker to indicate a LazyModule type.
+    Allows us to check module's with `isinstance(mod, _LazyModuleMarker)`
+    to know if the module is lazy.
+    """
     pass
 
 
-def make_lazy(module_name):
+def make_lazy(module_path):
+    """
+    Mark that this module should not be imported until an
+    attribute is needed off of it.
+    """
     sys_modules = sys.modules  # cache in the locals
-    module = None
+    module = None  # store our 'instance' data in the closure.
 
     class LazyModule(_LazyModuleMarker):
-        """Lazily import a module with minimal side effects"""
+        """
+        Lazily import a module with minimal side effects.
+        """
         def __mro__(self):
-            """Override the __mro__ to fool `isinstance`"""
+            """
+            Override the __mro__ to fool `isinstance`.
+            """
+            # We don't use direct subclassing because `ModuleType` has an
+            # incompatible metaclass base with object (they are both in c)
+            # and we are overridding __getattribute__.
+            # By putting a __mro__ method here, we can pass `isinstance`
+            # checks without ever invoking our __getattribute__ function.
             return (LazyModule, ModuleType)
 
         def __getattribute__(self, attr):
-            """Override __getattribute__ to hide the implementation details"""
+            """
+            Override __getattribute__ to hide the implementation details.
+            """
             nonlocal module
             if module is None:
-                del sys_modules[module_name]
-                module = __import__(module_name)
+                del sys_modules[module_path]
+                module = __import__(module_path)
 
-                sys_modules[module_name] = __import__(module_name)
+                sys_modules[module_path] = __import__(module_path)
 
             return getattr(module, attr)
 
-    sys_modules[module_name] = LazyModule()
+    sys_modules[module_path] = LazyModule()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lazyload',
-      version='0.0.1',
+      version='0.0.2',
       description='Force modules loaded later not to be loaded until attribute access',
       url='https://github.com/thomasballinger/lazyload',
       author='Thomas Ballinger',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 from setuptools import setup
-import ast
-import os
 
 setup(name='lazyload',
       version='0.0.1',

--- a/test.py
+++ b/test.py
@@ -14,6 +14,9 @@ class LazyLoadTestCase(unittest.TestCase):
         sys.modules.pop(self.modname, None)  # remove from the modules.
 
     def test_adds_to_modules(self):
+        """
+        Tests that `make_lazy` adds an entry to `sys.modules`.
+        """
         make_lazy(self.modname)
         abc = sys.modules.get(self.modname)
         self.assertIsNotNone(
@@ -27,12 +30,20 @@ class LazyLoadTestCase(unittest.TestCase):
         )
 
     def test_is_lazy_module(self):
+        """
+        Tests that `make_lazy` adds lazy module objects
+        instead of strict module objects.
+        """
         make_lazy(self.modname)
         mod = __import__(self.modname)
 
         self.assertIsInstance(mod, _LazyModuleMarker)
 
     def test_no_leaking_attributes(self):
+        """
+        Tests that consumers of the objects added by `make_lazy`
+        cannot accidently get the attributes off of the proxy.
+        """
         mod = __import__(self.modname)
         self.assertNotIsInstance(
             mod,

--- a/test.py
+++ b/test.py
@@ -1,19 +1,66 @@
+import sys
+from types import ModuleType
+import unittest
 
-import time
-t0 = time.time()
+from lazyload import make_lazy, _LazyModuleMarker
 
-import lazyload; lazyload.make_lazy('requests')
 
-t1 = time.time()
-import requests
+class LazyLoadTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.modname = 'abc'
 
-t2 = time.time()
-requests.get
-t3 = time.time()
-import requests
-t4 = time.time()
+    def tearDown(self):
+        sys.modules.pop(self.modname, None)  # remove from the modules.
 
-print 'time to make requests lazyloaded:', t1 - t0
-print 'time to lazyload requests:', t2 - t1
-print 'time to really load requests:', t3 - t2
-print 'time to import requests again:', t4 - t3
+    def test_adds_to_modules(self):
+        make_lazy(self.modname)
+        abc = sys.modules.get(self.modname)
+        self.assertIsNotNone(
+            abc,
+            'make_lazy failed to add {mod} to the system modules'.format(
+                mod=self.modname,
+            ),
+        )
+        self.assertIsInstance(
+            abc, ModuleType, '{mod} is not a module'.format(mod=self.modname),
+        )
+
+    def test_is_lazy_module(self):
+        make_lazy(self.modname)
+        mod = __import__(self.modname)
+
+        self.assertIsInstance(mod, _LazyModuleMarker)
+
+    def test_no_leaking_attributes(self):
+        mod = __import__(self.modname)
+        self.assertNotIsInstance(
+            mod,
+            _LazyModuleMarker,
+            '{mod} should not be lazy yet'.format(mod=self.modname),
+        )
+        self.assertFalse(
+            hasattr(mod, '__mro__'),
+            'The module object actually has an __mro__, pick another'
+            ' attribute to test',
+        )
+
+        make_lazy(self.modname)
+        mod = __import__(self.modname)
+        self.assertIsInstance(
+            mod,
+            _LazyModuleMarker,
+            '{mod} should now be lazy'.format(mod=self.modname),
+        )
+        self.assertFalse(
+            hasattr(mod, '__mro__'),
+            '{mod} should not leak the abstraction by exposing __mro__'.format(
+                mod=self.modname,
+            ),
+        )
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner().run(
+        unittest.defaultTestLoader.loadTestsFromTestCase(LazyLoadTestCase),
+    )


### PR DESCRIPTION
By closing over the module name and module, the user cannot access attributes off of the `LazyModule` object instead of the module being proxied. This also makes `isinstance` checks work on the `LazyModule` objects so that we don't fool valid python.

This also adds some standardized unit tests. Requests was being used in the test.py; however, it was not in the requirements so the tests use `abc` from the stdlib.

I also added the LICENSE file because I saw that this was in the setup.py. I apologize in advance if you think this is too much.

This has inspired me to work on a lazy importer for `lazy_python`.
